### PR TITLE
chore: bumped software versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-ARG IMAGE_TAG=3.12-bookworm
+ARG IMAGE_TAG=3.12.9-bookworm
 FROM docker.io/python:${IMAGE_TAG}
 
-LABEL version="1.1"
+LABEL version="3.12.9-1"
 LABEL description="A general purpose Python image with common Python packages installed that could be useful in AWS and Kubernetes environments."
 
 # Update the system and install some pre-requisites


### PR DESCRIPTION
Versions:

* Python: 3.12.9
* AWS CLI: 2.24.5
* Helm: 3.17.1
* Kubectl: 1.32.2